### PR TITLE
Change the Docker base image to reduce the image size

### DIFF
--- a/qiskit-docker-dev/Dockerfile
+++ b/qiskit-docker-dev/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8
+FROM python:3-slim
 
 RUN pip install -U pip
 


### PR DESCRIPTION
Thanks for this repository! I find it really interesting.

I think this change can be useful for you. With the current base image, the size of the result image is 2.05GB. Now, it is 1.27GB.